### PR TITLE
Fix: Remove persistance from the main json vis

### DIFF
--- a/src/lib/stores/json-visualizer-store.ts
+++ b/src/lib/stores/json-visualizer-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { createSelectors } from "./create-selectors";
-import { persist, createJSONStorage } from "zustand/middleware";
+// import { persist, createJSONStorage } from "zustand/middleware";
 
 export type TabValue = "input" | "tree" | "grid" | "ai";
 
@@ -29,29 +29,20 @@ interface JsonVisualizerState {
   setAIExplanation: (explanation: AIExplanation | null) => void;
 }
 
-const useJsonVisualizerStoreBase = create<JsonVisualizerState>()(
-  persist(
-    (set) => ({
-      activeTab: "input",
-      jsonInput: "",
-      parsedJson: null,
-      error: null,
-      isLoading: false,
-      aiExplanation: null,
-
-      setActiveTab: (tab) => set({ activeTab: tab }),
-      setJsonInput: (input) => set({ jsonInput: input }),
-      setParsedJson: (json) => set({ parsedJson: json }),
-      setError: (error) => set({ error }),
-      setIsLoading: (isLoading) => set({ isLoading }),
-      setAIExplanation: (explanation) => set({ aiExplanation: explanation }),
-    }),
-    {
-      name: "json-visualizer-storage",
-      storage: createJSONStorage(() => localStorage),
-    }
-  )
-);
+const useJsonVisualizerStoreBase = create<JsonVisualizerState>()((set) => ({
+  activeTab: "input",
+  jsonInput: "",
+  parsedJson: null,
+  error: null,
+  isLoading: false,
+  aiExplanation: null,
+  setActiveTab: (tab) => set({ activeTab: tab }),
+  setJsonInput: (input) => set({ jsonInput: input }),
+  setParsedJson: (json) => set({ parsedJson: json }),
+  setError: (error) => set({ error }),
+  setIsLoading: (isLoading) => set({ isLoading }),
+  setAIExplanation: (explanation) => set({ aiExplanation: explanation }),
+}));
 
 export const useJsonVisualizerStore = createSelectors(
   useJsonVisualizerStoreBase


### PR DESCRIPTION
Just removes global state persistance so users can use the tool to view diffrent jsons in multiple tabs